### PR TITLE
add match_on_name parameter to use for searching

### DIFF
--- a/app/controllers/players/__init__.py
+++ b/app/controllers/players/__init__.py
@@ -8,10 +8,17 @@ players = Blueprint("players", __name__, url_prefix="/players")
 @players.route("/")
 def get_players():
     pos = request.args.get('position')
+    name_matcher = request.args.get('match_on_name')
+
+    query = Player.query
 
     if pos:
-        players = Player.query.filter_by(
-            position=pos.upper()).order_by(desc('projection'))
-    else:
-        players = Player.query.all()
-    return jsonify([player.as_dict() for player in players])
+        query = query.filter_by(
+            position=pos.upper()
+            ). order_by(desc('projection'))
+
+    if name_matcher:
+        query = query.filter(Player.name.ilike(f"%{name_matcher}%"))
+
+    query = query.all()
+    return jsonify([player.as_dict() for player in query])


### PR DESCRIPTION
This adds a new parameter to the players endpoint. The `match_on_name` parameter is used for a case insensitive text matching on name. I have also updated the previous logic to allow for a combination of the two parameters, so you can search for players of specific positions with name matching