### PR TITLE
Change password field to a byte array

### DIFF
--- a/app/controllers/authenticate/__init__.py
+++ b/app/controllers/authenticate/__init__.py
@@ -14,7 +14,7 @@ def authenticate_user():
 
     user = User.query.filter_by(email=email).first()
 
-    if not user:
+    if user is None:
         return jsonify({"msg": "Invalid user"}), 400
 
     if user.password != password:

--- a/app/models/password/__init__.py
+++ b/app/models/password/__init__.py
@@ -1,9 +1,9 @@
-from sqlalchemy.types import TypeDecorator, String
+from sqlalchemy.types import TypeDecorator, LargeBinary
 from .passwordHash import PasswordHash
 
 
 class Password(TypeDecorator):
-    impl = String(128)
+    impl = LargeBinary
 
     def process_bind_param(self, value, dialect):
         return value.hash

--- a/app/models/password/passwordHash.py
+++ b/app/models/password/passwordHash.py
@@ -8,7 +8,10 @@ class PasswordHash:
         self.hash = hash
 
     def __eq__(self, potential):
-        return flask_bcrypt.check_password_hash(self.hash, potential)
+        try:
+            return flask_bcrypt.check_password_hash(self.hash, potential)
+        except ValueError:
+            return False
 
     @classmethod
     def from_password(cls, password):


### PR DESCRIPTION
This fixes an issue where the db was changing the encoding of the hashed password. Changing it to a byte array allows us to manage the encoding entirely on the app side